### PR TITLE
Add just-based workflows and GitHub release installer script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,10 @@ jobs:
               -o "$stage_dir/workspace-launcher" \
               ./cmd/workspace-launcher
             install -m 755 "$stage_dir/workspace-launcher" "dist/bin/workspace-launcher_${version_no_v}_${target}"
-            ln -sf workspace-launcher "$stage_dir/wl"
             install -m 644 LICENSE "$stage_dir/LICENSE"
             install -m 644 README.md "$stage_dir/README.md"
             install -m 644 VERSION "$stage_dir/VERSION"
-            tar -C "$stage_dir" -czf "dist/workspace-launcher_${version_no_v}_${target}.tar.gz" workspace-launcher wl LICENSE README.md VERSION
+            tar -C "$stage_dir" -czf "dist/workspace-launcher_${version_no_v}_${target}.tar.gz" workspace-launcher LICENSE README.md VERSION
           done
           (
             cd dist

--- a/README.md
+++ b/README.md
@@ -59,22 +59,12 @@ source <(workspace-launcher --bash)
 source <(workspace-launcher --zsh)
 ```
 
-```sh
-eval "$(workspace-launcher --zsh)"
-```
-
 ```fish
 workspace-launcher --fish | source
 ```
 
 Each integration defines `workspace-launcher-cd` and binds `Ctrl-G` to open the
 picker and `cd` directly in the current shell session.
-
-For `bash` and `zsh`, use `source <(...)` or `eval "$(…)"`. `eval <(...)`
-does not work because the shell expands the process substitution to a
-`/proc/self/fd/*` path and then tries to execute that path as a command.
-
-The shell scripts also live in [shell/key-bindings.bash](/home/lalvarezt/.t3/worktrees/workspace-launcher/t3code-db9a6af1/shell/key-bindings.bash), [shell/key-bindings.zsh](/home/lalvarezt/.t3/worktrees/workspace-launcher/t3code-db9a6af1/shell/key-bindings.zsh), and [shell/key-bindings.fish](/home/lalvarezt/.t3/worktrees/workspace-launcher/t3code-db9a6af1/shell/key-bindings.fish), mirroring `fzf`'s layout. Those files are the source templates; use `--bash`, `--zsh`, or `--fish` to emit a script with the correct binary path prelude.
 
 Rebind it with normal shell commands after sourcing:
 
@@ -131,9 +121,9 @@ WORKSPACE_LAUNCHER_RECENCY=git workspace-launcher --query fzf ~/src
 Usage: workspace-launcher [--bash|--zsh|--fish] [--query TEXT] [--[no-]language] [--[no-]git] [-v|--version] [ROOT]
 ```
 
-- `--bash`: print bash shell integration; load with `source <(workspace-launcher --bash)` or `eval "$(workspace-launcher --bash)"`
-- `--zsh`: print zsh shell integration; load with `source <(workspace-launcher --zsh)` or `eval "$(workspace-launcher --zsh)"`
-- `--fish`: print fish shell integration
+- `--bash`: print bash shell integration; load with `source <(workspace-launcher --bash)`
+- `--zsh`: print zsh shell integration; load with `source <(workspace-launcher --zsh)`
+- `--fish`: print fish shell integration; load with `workspace-launcher --fish | source`
 - `--query TEXT`: start with an initial query
 - `--language` / `--no-language`: show or hide the language column
 - `--git` / `--no-git`: show or hide the git-state column
@@ -156,45 +146,61 @@ Configuration is done with environment variables:
 
 ## Install
 
-Install the launcher with Go:
+Use `just` for the common local workflows:
+
+```sh
+just test
+just build
+just run -- --query fzf ~/src
+just install
+just bump-version v1.0.5
+```
+
+`just install` builds the local checkout and installs `workspace-launcher` and
+`bench-setup` into `${XDG_BIN_HOME:-$HOME/.local/bin}` by default, then creates
+`wl` as a symlink to `workspace-launcher`.
+
+The install logic also lives in `install.sh`, so the direct GitHub installer can
+look like this:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/lalvarezt/workspace-launcher/main/install.sh | bash
+```
+
+You can also install with Go:
 
 ```sh
 go install github.com/lalvarezt/workspace-launcher/cmd/workspace-launcher@latest
-```
-
-This installs `workspace-launcher` into `GOBIN` or `$(go env GOPATH)/bin`.
-
-Install the benchmark fixture generator with:
-
-```sh
 go install github.com/lalvarezt/workspace-launcher/cmd/bench-setup@latest
+ln -sfn workspace-launcher "${XDG_BIN_HOME:-$HOME/.local/bin}/wl"
 ```
 
 ## Local Build
 
-Build the launcher binary from a checkout:
+Build every local binary from a checkout:
 
 ```sh
-mkdir -p .build
-go build -ldflags "-X main.version=$(cat VERSION)" -o ./.build/workspace-launcher ./cmd/workspace-launcher
+just build
 ```
 
-Build the benchmark fixture generator:
+That produces:
 
-```sh
-go build -o ./.build/bench-setup ./cmd/bench-setup
-```
+- `./.build/workspace-launcher`
+- `./.build/bench-setup`
 
 Run the launcher directly after building:
 
 ```sh
-./.build/workspace-launcher
+just run
 ```
 
-Install from the local checkout into a custom bin dir:
+If you prefer direct Go commands, the launcher binaries use the shared version
+ldflag path:
 
 ```sh
-GOBIN="${XDG_BIN_HOME:-$HOME/.local/bin}" go install ./cmd/workspace-launcher
+mkdir -p .build
+go build -ldflags "-X main.version=$(cat VERSION)" -o ./.build/workspace-launcher ./cmd/workspace-launcher
+go build -o ./.build/bench-setup ./cmd/bench-setup
 ```
 
 Generate a large synthetic workspace tree for performance testing:

--- a/cmd/workspace-launcher/main.go
+++ b/cmd/workspace-launcher/main.go
@@ -304,8 +304,7 @@ Options:
 
 Shell integration:
   bash/zsh         Load with source <(workspace-launcher --bash|--zsh)
-                   or eval "$(workspace-launcher --bash|--zsh)"
-                   Do not use eval <(...).
+                   or workspace-launcher --fish | source
 
 Environment:
   WORKSPACE_LAUNCHER_ROOT           Default root directory (default: ~/git-repos)

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -3,9 +3,7 @@
 Create the synthetic fixture tree:
 
 ```sh
-mkdir -p .build
-go build -ldflags "-X main.version=$(cat VERSION)" -o ./.build/workspace-launcher ./cmd/workspace-launcher
-go build -o ./.build/bench-setup ./cmd/bench-setup
+just build
 ./.build/bench-setup
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_url="https://github.com/lalvarezt/workspace-launcher"
+bin_dir="${XDG_BIN_HOME:-$HOME/.local/bin}"
+ref="latest"
+stage_dir=""
+
+cleanup() {
+  if [[ -n "$stage_dir" ]]; then
+    rm -rf "$stage_dir"
+  fi
+}
+
+trap cleanup EXIT
+
+usage() {
+  cat <<'EOF'
+Usage: install.sh [REF] [--bin-dir DIR]
+
+Install workspace-launcher and the wl alias.
+
+Options:
+  --bin-dir DIR   Install into DIR instead of ${XDG_BIN_HOME:-$HOME/.local/bin}
+  -h, --help      Show this help text
+
+Arguments:
+  REF             Release tag to install, defaults to latest
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bin-dir)
+      shift
+      if [[ $# -eq 0 ]]; then
+        printf 'missing value for --bin-dir\n' >&2
+        exit 1
+      fi
+      bin_dir="$1"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      printf 'unknown option: %s\n' "$1" >&2
+      exit 1
+      ;;
+    *)
+      if [[ "$ref" != "latest" ]]; then
+        printf 'unexpected argument: %s\n' "$1" >&2
+        exit 1
+      fi
+      ref="$1"
+      ;;
+  esac
+  shift
+done
+
+mkdir -p "$bin_dir"
+
+install_alias() {
+  ln -sfn workspace-launcher "$bin_dir/wl"
+}
+
+resolve_tag() {
+  if [[ "$ref" != "latest" ]]; then
+    printf '%s\n' "$ref"
+    return 0
+  fi
+
+  local resolved
+  resolved="$(curl -fsSIL -o /dev/null -w '%{url_effective}' "$repo_url/releases/latest")"
+  basename "$resolved"
+}
+
+detect_target() {
+  local os
+  local arch
+
+  case "$(uname -s)" in
+    Linux)
+      os="linux"
+      ;;
+    Darwin)
+      os="darwin"
+      ;;
+    *)
+      printf 'unsupported operating system: %s\n' "$(uname -s)" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64|amd64)
+      arch="amd64"
+      ;;
+    arm64|aarch64)
+      arch="arm64"
+      ;;
+    *)
+      printf 'unsupported architecture: %s\n' "$(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+
+  printf '%s_%s\n' "$os" "$arch"
+}
+
+stage_dir="$(mktemp -d)"
+tag="$(resolve_tag)"
+target="$(detect_target)"
+version_no_v="${tag#v}"
+archive="workspace-launcher_${version_no_v}_${target}.tar.gz"
+url="$repo_url/releases/download/$tag/$archive"
+
+curl -fsSL "$url" -o "$stage_dir/$archive"
+tar -xzf "$stage_dir/$archive" -C "$stage_dir" workspace-launcher
+install -m 755 "$stage_dir/workspace-launcher" "$bin_dir/workspace-launcher"
+install_alias
+
+printf 'Installed workspace-launcher and wl to %s\n' "$bin_dir"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,48 @@
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+
+alias default := help
+
+help:
+    @just --list
+
+test:
+    go test ./...
+
+build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rm -rf .build
+    mkdir -p .build
+    go build -ldflags "-X main.version=$(cat VERSION)" -o ./.build/workspace-launcher ./cmd/workspace-launcher
+    go build -o ./.build/bench-setup ./cmd/bench-setup
+
+run *args:
+    just build
+    ./.build/workspace-launcher {{args}}
+
+install bin_dir="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just build
+    target="{{bin_dir}}"
+    if [[ -z "$target" ]]; then
+      target="${XDG_BIN_HOME:-$HOME/.local/bin}"
+    fi
+    mkdir -p "$target"
+    install -m 755 ./.build/workspace-launcher "$target/workspace-launcher"
+    install -m 755 ./.build/bench-setup "$target/bench-setup"
+    ln -sfn workspace-launcher "$target/wl"
+    printf 'Installed workspace-launcher, bench-setup, and wl to %s\n' "$target"
+
+bump-version version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{version}}" in
+      v[0-9]*.[0-9]*.[0-9]*) ;;
+      *)
+        printf 'version must look like v1.2.3\n' >&2
+        exit 1
+        ;;
+    esac
+    printf '%s\n' "{{version}}" > VERSION
+    perl -0pi -e 's/version-v[0-9]+\.[0-9]+\.[0-9]+-cb8d43\.svg/version-{{version}}-cb8d43.svg/' README.md


### PR DESCRIPTION
## Summary
- add a `justfile` with common project tasks: `test`, `build`, `run`, `install`, and `bump-version`
- add `install.sh` to install release binaries from GitHub (supports `latest` or explicit tag, target autodetection, and configurable `--bin-dir`)
- update release packaging to stop shipping the `wl` symlink inside archives
- refresh docs/help text to standardize shell integration guidance and prefer `just`-based local workflows
- update benchmarking docs to use `just build` for fixture setup

## Testing
- Not run (no runtime checks were provided in the commit)
- verified task wiring by inspection: `just build` produces both binaries and injects version ldflags for `workspace-launcher`
- verified installer flow by inspection: resolves release tag, detects OS/arch, downloads the matching archive, installs binary, and creates `wl` symlink