### PR TITLE
Support scanning and selecting workspaces across multiple root directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Search across several roots:
 workspace-launcher ~/src ~/.config
 ```
 
+When multiple roots are configured, the picker shows a left-side root context
+column to disambiguate duplicate workspace names. Filtering still matches the
+workspace-name column only.
+
 Seed the query:
 
 ```sh
@@ -229,6 +233,8 @@ go run ./cmd/bench-setup
 ## Notes
 
 - The launcher only scans the direct children of the selected roots.
+- When multiple roots are configured, the picker shows the shortest unique root label on the left.
+- Multi-root filtering only matches workspace names, not the root-context column.
 - When multiple roots are configured, `Ctrl-N` creates a new directory under the first root.
 - Language detection is heuristic-based and checks for common project files.
 - Git metadata is only shown for directories that contain `.git`.

--- a/cmd/workspace-launcher/main.go
+++ b/cmd/workspace-launcher/main.go
@@ -38,6 +38,9 @@ const (
 const (
 	columnGap      = "   "
 	gapWidth       = 3
+	rootMinWidth   = 8
+	rootMaxWidth   = 24
+	rootFloorWidth = 4
 	langWidth      = 12
 	langLabelWidth = langWidth - 3
 	gitWidth       = 5
@@ -64,31 +67,38 @@ const (
 )
 
 type config struct {
-	mode          string
-	shellBindings bool
-	initialQuery  string
-	roots         []string
-	jobs          int
-	gitDirty      bool
-	recency       string
-	showLanguage  bool
-	showGit       bool
-	headlessBench bool
-	now           int64
-	cwd           string
-	nameWidth     int
+	mode             string
+	shellBindings    bool
+	initialQuery     string
+	roots            []string
+	rootLabels       map[string]string
+	jobs             int
+	gitDirty         bool
+	recency          string
+	showLanguage     bool
+	showGit          bool
+	showRoot         bool
+	headlessBench    bool
+	now              int64
+	cwd              string
+	rootLabelWidth   int
+	nameWidth        int
+	searchFieldIndex int
 }
 
 type childDir struct {
-	name     string
-	path     string
-	modEpoch int64
+	name      string
+	path      string
+	root      string
+	rootLabel string
+	modEpoch  int64
 }
 
 type candidate struct {
-	path    string
-	display string
-	epoch   int64
+	path      string
+	display   string
+	matchText string
+	epoch     int64
 }
 
 type dirFacts struct {
@@ -109,6 +119,11 @@ type dirFacts struct {
 type gitLayout struct {
 	gitDir    string
 	commonDir string
+}
+
+type rootLabelParts struct {
+	clean string
+	parts []string
 }
 
 func main() {
@@ -265,6 +280,13 @@ func parseConfig(args []string) (config, error) {
 		return config{}, err
 	}
 	cfg.roots = resolvedRoots
+	cfg.showRoot = len(cfg.roots) > 1
+	cfg.searchFieldIndex = 1
+	if cfg.showRoot {
+		cfg.rootLabels = buildRootLabels(cfg.roots)
+		cfg.rootLabelWidth = computeRootLabelWidth(cfg.rootLabels)
+		cfg.searchFieldIndex = 2
+	}
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -285,6 +307,16 @@ func parseConfig(args []string) (config, error) {
 		metaWidth += gitWidth + gapWidth
 	}
 	cfg.nameWidth = cols - chromeWidth - metaWidth
+	if cfg.showRoot {
+		cfg.nameWidth -= cfg.rootLabelWidth + gapWidth
+		if cfg.nameWidth < 16 {
+			cfg.rootLabelWidth -= 16 - cfg.nameWidth
+			if cfg.rootLabelWidth < rootFloorWidth {
+				cfg.rootLabelWidth = rootFloorWidth
+			}
+			cfg.nameWidth = cols - chromeWidth - metaWidth - cfg.rootLabelWidth - gapWidth
+		}
+	}
 	if cfg.nameWidth < 16 {
 		cfg.nameWidth = 16
 	}
@@ -390,9 +422,11 @@ func buildCandidates(cfg config) ([]candidate, error) {
 				continue
 			}
 			children = append(children, childDir{
-				name:     entry.Name(),
-				path:     path,
-				modEpoch: info.ModTime().Unix(),
+				name:      entry.Name(),
+				path:      path,
+				root:      root,
+				rootLabel: cfg.rootLabels[root],
+				modEpoch:  info.ModTime().Unix(),
 			})
 		}
 	}
@@ -531,30 +565,132 @@ func describeRepo(cfg config, child childDir, inspect bool) (candidate, error) {
 	if isCurrentRepo(cfg.cwd, child.path) {
 		markerField = paintField(cCurrent, "*")
 	}
-	nameField := paintField(cName, fitField(child.name, cfg.nameWidth))
+	nameField := markerField + " " + paintField(cName, fitField(child.name, cfg.nameWidth))
 	ageField := paintField(cTime, fitField(formatAge(cfg.now, epoch), ageWidth))
 
-	var display strings.Builder
-	display.Grow(len(child.name) + 96)
-	display.WriteString(markerField)
-	display.WriteString(" ")
-	display.WriteString(nameField)
+	fields := make([]string, 0, 4)
+	if cfg.showRoot {
+		fields = append(fields, paintField(cDim, fitField(child.rootLabel, cfg.rootLabelWidth)))
+	}
+	fields = append(fields, nameField)
 	if cfg.showLanguage {
-		display.WriteString(columnGap)
-		display.WriteString(renderLangField(lang))
+		fields = append(fields, renderLangField(lang))
 	}
 	if cfg.showGit {
-		display.WriteString(columnGap)
-		display.WriteString(renderGitField(gitState))
+		fields = append(fields, renderGitField(gitState))
 	}
-	display.WriteString(columnGap)
-	display.WriteString(ageField)
+	fields = append(fields, ageField)
 
 	return candidate{
-		path:    child.path,
-		display: display.String(),
-		epoch:   epoch,
+		path:      child.path,
+		display:   strings.Join(fields, "\t"),
+		matchText: child.name,
+		epoch:     epoch,
 	}, nil
+}
+
+func buildRootLabels(roots []string) map[string]string {
+	labels := make(map[string]string, len(roots))
+	if len(roots) == 0 {
+		return labels
+	}
+
+	partsByRoot := make(map[string]rootLabelParts, len(roots))
+	depths := make(map[string]int, len(roots))
+	for _, root := range roots {
+		clean := filepath.Clean(root)
+		partsByRoot[root] = rootLabelParts{
+			clean: clean,
+			parts: splitPathParts(clean),
+		}
+		depths[root] = 1
+	}
+
+	for {
+		groups := make(map[string][]string, len(roots))
+		for _, root := range roots {
+			label := rootLabelAtDepth(partsByRoot[root], depths[root])
+			groups[label] = append(groups[label], root)
+		}
+
+		collisions := false
+		progressed := false
+		for label, group := range groups {
+			if len(group) == 1 {
+				labels[group[0]] = label
+				continue
+			}
+			collisions = true
+			for _, root := range group {
+				info := partsByRoot[root]
+				if depths[root] < len(info.parts) {
+					depths[root]++
+					progressed = true
+					continue
+				}
+				labels[root] = info.clean
+			}
+		}
+
+		if !collisions {
+			return labels
+		}
+		if !progressed {
+			for _, root := range roots {
+				if _, ok := labels[root]; !ok {
+					labels[root] = partsByRoot[root].clean
+				}
+			}
+			return labels
+		}
+	}
+}
+
+func splitPathParts(path string) []string {
+	clean := filepath.Clean(path)
+	volume := filepath.VolumeName(clean)
+	remainder := strings.TrimPrefix(clean, volume)
+	remainder = strings.TrimPrefix(remainder, string(filepath.Separator))
+	if remainder == "" {
+		return nil
+	}
+	parts := strings.Split(remainder, string(filepath.Separator))
+	out := parts[:0]
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		out = append(out, part)
+	}
+	return out
+}
+
+func rootLabelAtDepth(info rootLabelParts, depth int) string {
+	if len(info.parts) == 0 {
+		return info.clean
+	}
+	if depth > len(info.parts) {
+		depth = len(info.parts)
+	}
+	start := len(info.parts) - depth
+	if start < 0 {
+		start = 0
+	}
+	return filepath.Join(info.parts[start:]...)
+}
+
+func computeRootLabelWidth(labels map[string]string) int {
+	longest := rootMinWidth
+	for _, label := range labels {
+		width := utf8.RuneCountInString(label)
+		if width > longest {
+			longest = width
+		}
+	}
+	if longest > rootMaxWidth {
+		return rootMaxWidth
+	}
+	return longest
 }
 
 func detectLanguage(facts dirFacts) string {
@@ -841,6 +977,7 @@ func pickRepo(cfg config, fzfPath string, candidates []candidate) (string, error
 		"--info=hidden",
 		"--delimiter=\t",
 		"--with-nth=2..",
+		"--nth="+strconv.Itoa(cfg.searchFieldIndex),
 		"--expect=ctrl-e",
 		"--query="+cfg.initialQuery,
 		"--bind=enter:accept-or-print-query",
@@ -878,8 +1015,8 @@ func pickRepo(cfg config, fzfPath string, candidates []candidate) (string, error
 func pickRepoHeadless(cfg config, candidates []candidate) (string, error) {
 	query := strings.ToLower(cfg.initialQuery)
 	for _, cand := range candidates {
-		line := cand.path + "\t" + cand.display
-		if query == "" || strings.Contains(strings.ToLower(line), query) {
+		line := serializeCandidate(cand)
+		if query == "" || strings.Contains(strings.ToLower(cand.matchText), query) {
 			return line, nil
 		}
 	}
@@ -890,13 +1027,7 @@ func writeCandidates(w io.WriteCloser, candidates []candidate) error {
 	defer w.Close()
 	buf := bufio.NewWriterSize(w, 1<<20)
 	for _, cand := range candidates {
-		if _, err := buf.WriteString(cand.path); err != nil {
-			return err
-		}
-		if _, err := buf.WriteString("\t"); err != nil {
-			return err
-		}
-		if _, err := buf.WriteString(cand.display); err != nil {
+		if _, err := buf.WriteString(serializeCandidate(cand)); err != nil {
 			return err
 		}
 		if err := buf.WriteByte('\n'); err != nil {
@@ -904,6 +1035,10 @@ func writeCandidates(w io.WriteCloser, candidates []candidate) error {
 		}
 	}
 	return buf.Flush()
+}
+
+func serializeCandidate(cand candidate) string {
+	return cand.path + "\t" + cand.display
 }
 
 func splitResult(result string) (string, string) {

--- a/cmd/workspace-launcher/main_test.go
+++ b/cmd/workspace-launcher/main_test.go
@@ -177,13 +177,13 @@ func TestBuildCandidatesIncludesAllRoots(t *testing.T) {
 	makeDir(t, filepath.Join(rootB, "beta"), 1700002000, "")
 
 	cfg := config{
-		roots:        []string{rootA, rootB},
-		jobs:         2,
-		recency:      recencyMtime,
-		showLanguage: false,
-		showGit:      false,
-		now:          1700003000,
-		nameWidth:    32,
+		roots:      []string{rootA, rootB},
+		rootLabels: map[string]string{rootA: "alpha-root", rootB: "beta-root"},
+		showRoot:   true,
+		jobs:       2,
+		recency:    recencyMtime,
+		now:        1700003000,
+		nameWidth:  32,
 	}
 
 	cands, err := buildCandidates(cfg)
@@ -207,8 +207,8 @@ func TestBuildCandidatesIncludesAllRoots(t *testing.T) {
 func TestPickRepoHeadlessSelectsFirstCandidate(t *testing.T) {
 	cfg := config{headlessBench: true}
 	candidates := []candidate{
-		{path: "/tmp/b", display: "beta"},
-		{path: "/tmp/a", display: "alpha"},
+		{path: "/tmp/b", display: "beta", matchText: "beta"},
+		{path: "/tmp/a", display: "alpha", matchText: "alpha"},
 	}
 
 	got, err := pickRepoHeadless(cfg, candidates)
@@ -223,8 +223,8 @@ func TestPickRepoHeadlessSelectsFirstCandidate(t *testing.T) {
 func TestPickRepoHeadlessFiltersByQuery(t *testing.T) {
 	cfg := config{headlessBench: true, initialQuery: "alp"}
 	candidates := []candidate{
-		{path: "/tmp/b", display: "beta"},
-		{path: "/tmp/a", display: "alpha"},
+		{path: "/tmp/b", display: "beta", matchText: "beta"},
+		{path: "/tmp/a", display: "alpha", matchText: "alpha"},
 	}
 
 	got, err := pickRepoHeadless(cfg, candidates)
@@ -233,6 +233,122 @@ func TestPickRepoHeadlessFiltersByQuery(t *testing.T) {
 	}
 	if got != "/tmp/a\talpha" {
 		t.Fatalf("unexpected filtered selection: %q", got)
+	}
+}
+
+func TestPickRepoHeadlessOnlyMatchesNameField(t *testing.T) {
+	cfg := config{headlessBench: true, initialQuery: "archive"}
+	candidates := []candidate{
+		{path: "/tmp/archive/api", display: "archive\tapi", matchText: "api"},
+	}
+
+	_, err := pickRepoHeadless(cfg, candidates)
+	if err == nil {
+		t.Fatal("expected query against root column to miss")
+	}
+}
+
+func TestBuildRootLabelsUsesShortestUniqueSuffix(t *testing.T) {
+	roots := []string{
+		filepath.Join(string(filepath.Separator), "mnt", "a", "src"),
+		filepath.Join(string(filepath.Separator), "mnt", "b", "src"),
+		filepath.Join(string(filepath.Separator), "mnt", "archive"),
+	}
+
+	got := buildRootLabels(roots)
+
+	if got[roots[0]] != filepath.Join("a", "src") {
+		t.Fatalf("unexpected label for first root: %q", got[roots[0]])
+	}
+	if got[roots[1]] != filepath.Join("b", "src") {
+		t.Fatalf("unexpected label for second root: %q", got[roots[1]])
+	}
+	if got[roots[2]] != "archive" {
+		t.Fatalf("unexpected label for third root: %q", got[roots[2]])
+	}
+}
+
+func TestDescribeRepoIncludesRootFieldWhenMultiRoot(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	repoA := filepath.Join(rootA, "api")
+	repoB := filepath.Join(rootB, "api")
+	makeDir(t, repoA, 1700001000, "")
+	makeDir(t, repoB, 1700002000, "")
+
+	cfg := config{
+		showRoot:       true,
+		showLanguage:   false,
+		showGit:        false,
+		now:            1700003000,
+		nameWidth:      20,
+		rootLabelWidth: 12,
+	}
+
+	candA, err := describeRepo(cfg, childDir{
+		name:      "api",
+		path:      repoA,
+		root:      rootA,
+		rootLabel: "src",
+		modEpoch:  1700001000,
+	}, false)
+	if err != nil {
+		t.Fatalf("describeRepo returned error: %v", err)
+	}
+	candB, err := describeRepo(cfg, childDir{
+		name:      "api",
+		path:      repoB,
+		root:      rootB,
+		rootLabel: "archive",
+		modEpoch:  1700002000,
+	}, false)
+	if err != nil {
+		t.Fatalf("describeRepo returned error: %v", err)
+	}
+
+	fieldsA := strings.Split(candA.display, "\t")
+	fieldsB := strings.Split(candB.display, "\t")
+	if len(fieldsA) != 3 || len(fieldsB) != 3 {
+		t.Fatalf("unexpected field count: got %d and %d want 3", len(fieldsA), len(fieldsB))
+	}
+	if !strings.Contains(fieldsA[0], "src") || !strings.Contains(fieldsB[0], "archive") {
+		t.Fatalf("unexpected root fields: %q %q", fieldsA[0], fieldsB[0])
+	}
+	if !strings.Contains(fieldsA[1], "api") || !strings.Contains(fieldsB[1], "api") {
+		t.Fatalf("unexpected name fields: %q %q", fieldsA[1], fieldsB[1])
+	}
+	if fieldsA[0] == fieldsB[0] {
+		t.Fatalf("expected distinct root fields, got %q", fieldsA[0])
+	}
+}
+
+func TestDescribeRepoOmitsRootFieldWhenSingleRoot(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "api")
+	makeDir(t, repo, 1700001000, "")
+
+	cfg := config{
+		showRoot:     false,
+		showLanguage: false,
+		showGit:      false,
+		now:          1700003000,
+		nameWidth:    20,
+	}
+
+	cand, err := describeRepo(cfg, childDir{
+		name:     "api",
+		path:     repo,
+		modEpoch: 1700001000,
+	}, false)
+	if err != nil {
+		t.Fatalf("describeRepo returned error: %v", err)
+	}
+
+	fields := strings.Split(cand.display, "\t")
+	if len(fields) != 2 {
+		t.Fatalf("unexpected field count: got %d want %d", len(fields), 2)
+	}
+	if !strings.Contains(fields[0], "api") {
+		t.Fatalf("unexpected first visible field: %q", fields[0])
 	}
 }
 
@@ -397,6 +513,39 @@ func TestParseConfigTreatsPositionalRootAsSinglePath(t *testing.T) {
 	}
 	if cfg.roots[0] != root {
 		t.Fatalf("unexpected root: got %q want %q", cfg.roots[0], root)
+	}
+}
+
+func TestParseConfigSetsMultiRootColumnMetadata(t *testing.T) {
+	rootA := filepath.Join(t.TempDir(), "src")
+	rootB := filepath.Join(t.TempDir(), "archive")
+	if err := os.MkdirAll(rootA, 0o755); err != nil {
+		t.Fatalf("mkdir rootA: %v", err)
+	}
+	if err := os.MkdirAll(rootB, 0o755); err != nil {
+		t.Fatalf("mkdir rootB: %v", err)
+	}
+	t.Setenv("COLUMNS", "40")
+
+	cfg, err := parseConfig([]string{rootA, rootB})
+	if err != nil {
+		t.Fatalf("parseConfig returned error: %v", err)
+	}
+
+	if !cfg.showRoot {
+		t.Fatal("expected root column to be enabled")
+	}
+	if cfg.searchFieldIndex != 2 {
+		t.Fatalf("unexpected searchFieldIndex: got %d want %d", cfg.searchFieldIndex, 2)
+	}
+	if cfg.nameWidth < 16 {
+		t.Fatalf("expected nameWidth >= 16, got %d", cfg.nameWidth)
+	}
+	if cfg.rootLabelWidth < rootFloorWidth || cfg.rootLabelWidth > rootMaxWidth {
+		t.Fatalf("unexpected rootLabelWidth: %d", cfg.rootLabelWidth)
+	}
+	if cfg.rootLabels[rootA] != "src" || cfg.rootLabels[rootB] != "archive" {
+		t.Fatalf("unexpected root labels: %v", cfg.rootLabels)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Allow `workspace-launcher` to accept multiple roots via CLI args (`[ROOT...]`) and `WORKSPACE_LAUNCHER_ROOT` path-list values.
- Replace single-root config handling with normalized and deduplicated `roots` resolution and validation.
- Scan direct child directories across all configured roots when building candidate lists.
- Preserve positional CLI roots as single paths, so valid directory names containing the OS path-list separator are not split accidentally.
- Add a left-side root-context column in multi-root mode using the shortest unique root-derived label so duplicate workspace basenames are visually distinguishable.
- Restrict interactive and headless matching to the workspace-name column only, while keeping the hidden path field for selection/edit behavior.
- Keep new-workspace creation deterministic by creating under the first configured root.
- Update README usage, behavior notes, and env var docs to reflect multi-root behavior and the new root-context column.
- Expand tests to cover multi-root parsing, candidate discovery, shortest-unique root labels, root-column rendering, narrowed matching scope, positional root regression handling, and creation under the first root.

## Behavior Details
- `WORKSPACE_LAUNCHER_ROOT` still accepts multiple roots via the OS path-list separator.
- Positional CLI roots are treated as atomic argv values and are no longer reparsed with `filepath.SplitList`.
- When multiple roots are configured, picker rows render as:
  - `<root-context>   <marker+workspace-name>   <language?>   <git?>   <age>`
- The root-context column is display-only; filtering matches the workspace-name column, not the root label or hidden path.
- If two roots share the same basename, the displayed root label expands to the shortest unique suffix (for example `a/src` vs `b/src`).

## Testing
- `go test ./...`
- Verified `parseConfig` accepts multiple positional roots and splits `WORKSPACE_LAUNCHER_ROOT` using the OS path-list separator.
- Verified positional roots containing `:` remain a single root on Unix.
- Verified `buildCandidates` returns entries from all configured roots.
- Verified multi-root candidate rendering includes distinct root-context labels for duplicate workspace names.
- Verified headless matching only matches the workspace-name field.
- Verified `resolveSelection` still creates new directories under `cfg.roots[0]`.
- Verified with `fzf --filter` that the visible root-context column does not affect matching, while the workspace-name column still does.
