### PR TITLE
Improve repo picker search by separating branch matching and enabling fzf history scheme

### DIFF
--- a/cmd/workspace-launcher/main.go
+++ b/cmd/workspace-launcher/main.go
@@ -105,10 +105,11 @@ type childDir struct {
 }
 
 type candidate struct {
-	path      string
-	display   string
-	matchText string
-	epoch     int64
+	path       string
+	display    string
+	matchText  string
+	branchText string
+	epoch      int64
 }
 
 type repoDetails struct {
@@ -530,16 +531,11 @@ func inspectRepo(cfg config, child childDir, inspect bool) (repoDetails, error) 
 		lang = detectLanguage(facts)
 	}
 
-	matchText := child.name
-	if git.branchLabel != "" && git.branchLabel != "-" {
-		matchText += " " + git.branchLabel
-	}
-
 	return repoDetails{
 		child:     child,
 		lang:      lang,
 		git:       git,
-		matchText: matchText,
+		matchText: child.name,
 		epoch:     epoch,
 	}, nil
 }
@@ -580,10 +576,11 @@ func renderCandidates(cfg config, details []repoDetails) []candidate {
 		fields = append(fields, ageField)
 
 		out[i] = candidate{
-			path:      detail.child.path,
-			display:   strings.Join(fields, "\t"),
-			matchText: detail.matchText,
-			epoch:     detail.epoch,
+			path:       detail.child.path,
+			display:    strings.Join(fields, "\t"),
+			matchText:  detail.matchText,
+			branchText: branchSearchText(detail.git.branchLabel),
+			epoch:      detail.epoch,
 		}
 	}
 	return out
@@ -1230,9 +1227,9 @@ func pickRepo(cfg config, fzfPath string, candidates []candidate) (string, error
 		return pickRepoHeadless(cfg, candidates)
 	}
 
-	cmd := exec.Command(
-		fzfPath,
+	args := []string{
 		"--ansi",
+		"--scheme=history",
 		"--layout=reverse",
 		"--prompt=",
 		"--pointer=▌",
@@ -1250,14 +1247,15 @@ func pickRepo(cfg config, fzfPath string, candidates []candidate) (string, error
 		"--footer-border=line",
 		"--info=hidden",
 		"--delimiter=\t",
-		"--with-nth=3..",
-		"--nth=2",
+		"--with-nth=5..",
+		"--nth=2,4",
 		"--expect=ctrl-e",
-		"--query="+cfg.initialQuery,
+		"--query=" + cfg.initialQuery,
 		"--bind=enter:accept-or-print-query",
 		"--bind=ctrl-n:print-query+accept",
 		"--bind=result:transform-list-label:printf \" Folders (%s) \" \"$FZF_MATCH_COUNT\"",
-	)
+	}
+	cmd := exec.Command(fzfPath, args...)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -1292,7 +1290,7 @@ func pickRepoHeadless(cfg config, candidates []candidate) (string, error) {
 	query := strings.ToLower(cfg.initialQuery)
 	for _, cand := range candidates {
 		line := serializeCandidate(cand)
-		if query == "" || strings.Contains(strings.ToLower(cand.matchText), query) {
+		if query == "" || strings.Contains(strings.ToLower(candidateSearchText(cand)), query) {
 			return line, nil
 		}
 	}
@@ -1323,7 +1321,21 @@ func isClosedPickerPipe(err error) bool {
 }
 
 func serializeCandidate(cand candidate) string {
-	return cand.path + "\t" + cand.matchText + "\t" + cand.display
+	return cand.path + "\t" + cand.matchText + "\t\t" + cand.branchText + "\t" + cand.display
+}
+
+func candidateSearchText(cand candidate) string {
+	if cand.branchText == "" {
+		return cand.matchText
+	}
+	return cand.matchText + " " + cand.branchText
+}
+
+func branchSearchText(branch string) string {
+	if branch == "" || branch == "-" {
+		return ""
+	}
+	return branch
 }
 
 func splitResult(result string) (string, string) {

--- a/cmd/workspace-launcher/main_test.go
+++ b/cmd/workspace-launcher/main_test.go
@@ -310,7 +310,7 @@ func TestPickRepoHeadlessSelectsFirstCandidate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pickRepoHeadless returned error: %v", err)
 	}
-	if got != "/tmp/b\tbeta\tbeta" {
+	if got != "/tmp/b\tbeta\t\t\tbeta" {
 		t.Fatalf("unexpected selection: %q", got)
 	}
 }
@@ -326,7 +326,7 @@ func TestPickRepoHeadlessFiltersByQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pickRepoHeadless returned error: %v", err)
 	}
-	if got != "/tmp/a\talpha\talpha" {
+	if got != "/tmp/a\talpha\t\t\talpha" {
 		t.Fatalf("unexpected filtered selection: %q", got)
 	}
 }
@@ -346,14 +346,14 @@ func TestPickRepoHeadlessOnlyMatchesNameField(t *testing.T) {
 func TestPickRepoHeadlessMatchesBranchField(t *testing.T) {
 	cfg := config{headlessBench: true, initialQuery: "worktree-ui"}
 	candidates := []candidate{
-		{path: "/tmp/repo", display: "repo", matchText: "repo feature/worktree-ui"},
+		{path: "/tmp/repo", display: "repo", matchText: "repo", branchText: "feature/worktree-ui"},
 	}
 
 	got, err := pickRepoHeadless(cfg, candidates)
 	if err != nil {
 		t.Fatalf("pickRepoHeadless returned error: %v", err)
 	}
-	if got != "/tmp/repo\trepo feature/worktree-ui\trepo" {
+	if got != "/tmp/repo\trepo\t\tfeature/worktree-ui\trepo" {
 		t.Fatalf("unexpected branch selection: %q", got)
 	}
 }
@@ -367,6 +367,34 @@ func TestPickRepoReturnsEmptyOnAbortExit(t *testing.T) {
 	}
 	if result != "" {
 		t.Fatalf("expected empty result on abort, got %q", result)
+	}
+}
+
+func TestPickRepoPassesHistoryScheme(t *testing.T) {
+	argsPath := filepath.Join(t.TempDir(), "args.txt")
+	quotedArgsPath := "'" + strings.ReplaceAll(argsPath, "'", "'\\''") + "'"
+	fzfPath := writeTestScript(t, "#!/bin/sh\nprintf '%s\n' \"$@\" > "+quotedArgsPath+"\nexit 130\n")
+
+	result, err := pickRepo(config{}, fzfPath, []candidate{{path: "/tmp/repo", display: "repo", matchText: "repo"}})
+	if err != nil {
+		t.Fatalf("pickRepo returned error: %v", err)
+	}
+	if result != "" {
+		t.Fatalf("expected empty result on abort, got %q", result)
+	}
+
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read recorded args: %v", err)
+	}
+	if !strings.Contains(string(args), "--scheme=history\n") {
+		t.Fatalf("expected --scheme=history in fzf args, got %q", string(args))
+	}
+	if !strings.Contains(string(args), "--with-nth=5..\n") {
+		t.Fatalf("expected --with-nth=5.. in fzf args, got %q", string(args))
+	}
+	if !strings.Contains(string(args), "--nth=2,4\n") {
+		t.Fatalf("expected --nth=2,4 in fzf args, got %q", string(args))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Split candidate search data into separate name and branch fields instead of combining them into one string.
- Include branch text as a dedicated searchable column, and update headless matching to search both name and branch.
- Update fzf invocation to use `--scheme=history`, adjust visible fields to `--with-nth=5..`, and match on `--nth=2,4`.
- Keep branch search text empty for unknown branch labels (`""` or `"-"`) via `branchSearchText`.
- Add/adjust tests for serialized output format, branch-field matching, and fzf argument coverage.

## Testing
- `go test ./cmd/workspace-launcher -run TestPickRepoHeadlessSelectsFirstCandidate` (expected updated serialized output with branch column).
- `go test ./cmd/workspace-launcher -run TestPickRepoHeadlessFiltersByQuery` (expected query filtering still works).
- `go test ./cmd/workspace-launcher -run TestPickRepoHeadlessMatchesBranchField` (verifies branch-only query matches).
- `go test ./cmd/workspace-launcher -run TestPickRepoPassesHistoryScheme` (verifies `--scheme=history`, `--with-nth=5..`, `--nth=2,4`).
- Not run in this PR description context.