### PR TITLE
Adjust fzf search `--nth` columns when optional fields are enabled

### DIFF
--- a/cmd/workspace-launcher/main.go
+++ b/cmd/workspace-launcher/main.go
@@ -1248,7 +1248,7 @@ func pickRepo(cfg config, fzfPath string, candidates []candidate) (string, error
 		"--info=hidden",
 		"--delimiter=\t",
 		"--with-nth=5..",
-		"--nth=2,4",
+		"--nth=" + fzfSearchNth(cfg),
 		"--expect=ctrl-e",
 		"--query=" + cfg.initialQuery,
 		"--bind=enter:accept-or-print-query",
@@ -1284,6 +1284,25 @@ func pickRepo(cfg config, fzfPath string, candidates []candidate) (string, error
 		return "", waitErr
 	}
 	return strings.TrimRight(stdout.String(), "\n"), nil
+}
+
+func fzfSearchNth(cfg config) string {
+	columns := make([]string, 0, 2)
+	column := 1
+	if cfg.showRoot {
+		column++
+	}
+
+	columns = append(columns, strconv.Itoa(column))
+	column++
+	if cfg.showLanguage {
+		column++
+	}
+	if cfg.showGit {
+		columns = append(columns, strconv.Itoa(column))
+	}
+
+	return strings.Join(columns, ",")
 }
 
 func pickRepoHeadless(cfg config, candidates []candidate) (string, error) {

--- a/cmd/workspace-launcher/main_test.go
+++ b/cmd/workspace-launcher/main_test.go
@@ -375,7 +375,7 @@ func TestPickRepoPassesHistoryScheme(t *testing.T) {
 	quotedArgsPath := "'" + strings.ReplaceAll(argsPath, "'", "'\\''") + "'"
 	fzfPath := writeTestScript(t, "#!/bin/sh\nprintf '%s\n' \"$@\" > "+quotedArgsPath+"\nexit 130\n")
 
-	result, err := pickRepo(config{}, fzfPath, []candidate{{path: "/tmp/repo", display: "repo", matchText: "repo"}})
+	result, err := pickRepo(config{showRoot: true, showLanguage: true, showGit: true}, fzfPath, []candidate{{path: "/tmp/repo", display: "repo", matchText: "repo"}})
 	if err != nil {
 		t.Fatalf("pickRepo returned error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Update `pickRepo` to compute `fzf --nth` dynamically via a new `fzfSearchNth(cfg)` helper.
- Ensure search targets the correct tab-delimited columns when `showRoot`, `showLanguage`, and/or `showGit` are enabled.
- Update `TestPickRepoPassesHistoryScheme` to run with optional columns enabled so argument wiring is validated for that layout.

## Testing
- Not run (no test execution output provided in this patch).
- Verified from diff that `--nth` now uses `fzfSearchNth(cfg)` instead of a fixed `2,4`.
- Verified test setup now uses `config{showRoot: true, showLanguage: true, showGit: true}` to cover optional-field column offsets.