### PR TITLE
Add native Go benchmarks and optimize headless/git hot paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,11 @@ go run ./cmd/bench-setup
 
 ## Benchmarking
 
-Benchmark fixture setup and `hyperfine` examples live in
-[`docs/benchmarking.md`](docs/benchmarking.md).
+Two benchmarking workflows are documented in
+[`docs/benchmarking.md`](docs/benchmarking.md):
+
+- `just bench-go` for native `go test -bench` coverage of core hot paths
+- `just bench` for end-to-end headless timing with `hyperfine`
 
 ## Acknowledgements
 

--- a/cmd/workspace-launcher/display.go
+++ b/cmd/workspace-launcher/display.go
@@ -122,7 +122,11 @@ func formatAge(now, epoch int64) string {
 func computeAgeColumnWidth(now int64, details []repoDetails) int {
 	width := ageWidth
 	for _, detail := range details {
-		currentWidth := displayWidth(formatAge(now, detail.epoch)) + 1
+		age := detail.ageText
+		if age == "" {
+			age = formatAge(now, detail.epoch)
+		}
+		currentWidth := displayWidth(age) + 1
 		if currentWidth > width {
 			width = currentWidth
 		}
@@ -207,15 +211,29 @@ func joinDisplayFields(fields []string) string {
 		return ""
 	}
 
-	padded := make([]string, len(fields))
+	totalLen := 0
+	for _, field := range fields {
+		totalLen += len(field)
+	}
+	if len(fields) > 1 {
+		totalLen += (len(fields) - 1) * gapWidth
+	}
+
+	var b strings.Builder
+	b.Grow(totalLen)
 	for i, field := range fields {
-		padded[i] = field
+		if i > 0 {
+			b.WriteByte('\t')
+		}
+		b.WriteString(field)
 		if i < len(fields)-1 && gapWidth > 1 {
-			padded[i] += strings.Repeat(" ", gapWidth-1)
+			for range gapWidth - 1 {
+				b.WriteByte(' ')
+			}
 		}
 	}
 
-	return strings.Join(padded, "\t")
+	return b.String()
 }
 
 func displayWidth(text string) int {
@@ -313,16 +331,11 @@ func renderAgeFieldStyled(age string, width int, styled bool) string {
 		return paintFieldStyled(styled, cTime, fitFieldRight(text, width))
 	}
 
-	blocks := strings.Fields(age)
-	candidates := []string{age}
-	if len(blocks) >= 2 {
-		candidates = append(candidates, strings.Join(blocks[:2], " "))
-	}
-	if len(blocks) >= 1 {
-		candidates = append(candidates, blocks[0])
-	}
-
-	for _, candidate := range candidates {
+	firstBlock, twoBlocks, ok := ageBlocks(age)
+	for _, candidate := range [...]string{age, twoBlocks, firstBlock} {
+		if candidate == "" {
+			continue
+		}
 		if displayWidth(candidate)+1 <= width {
 			return render(candidate, true)
 		}
@@ -330,11 +343,10 @@ func renderAgeFieldStyled(age string, width int, styled bool) string {
 			return render(candidate, false)
 		}
 	}
-
-	if len(blocks) == 0 {
+	if !ok {
 		return render(age, false)
 	}
-	return render(blocks[0], false)
+	return render(firstBlock, false)
 }
 
 func renderLangFieldStyled(lang string, width int, styled bool) string {
@@ -410,4 +422,19 @@ func renderGitFieldStyled(meta gitMeta, branch string, width int, styled bool) s
 	}
 
 	return paintFieldStyled(styled, color, fitField(gitFieldText(meta, branch), width))
+}
+
+func ageBlocks(age string) (string, string, bool) {
+	firstSpace := strings.IndexByte(age, ' ')
+	if firstSpace < 0 {
+		return "", "", false
+	}
+	firstBlock := age[:firstSpace]
+
+	secondSpaceRel := strings.IndexByte(age[firstSpace+1:], ' ')
+	if secondSpaceRel < 0 {
+		return firstBlock, "", true
+	}
+	secondSpace := firstSpace + 1 + secondSpaceRel
+	return firstBlock, age[:secondSpace], true
 }

--- a/cmd/workspace-launcher/git.go
+++ b/cmd/workspace-launcher/git.go
@@ -215,14 +215,14 @@ func finalizeGitLayout(gitDir string) (gitLayout, error) {
 		gitDir:    gitDir,
 		commonDir: gitDir,
 	}
-	content, err := os.ReadFile(filepath.Join(gitDir, "commondir"))
+	content, err := readTrimmedSmallFile(filepath.Join(gitDir, "commondir"))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return layout, nil
 		}
 		return gitLayout{}, err
 	}
-	commonDir := strings.TrimSpace(string(content))
+	commonDir := content
 	if commonDir == "" {
 		return layout, nil
 	}
@@ -234,11 +234,10 @@ func finalizeGitLayout(gitDir string) (gitLayout, error) {
 }
 
 func readHeadFile(gitDir string) (string, error) {
-	content, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	head, err := readTrimmedSmallFile(filepath.Join(gitDir, "HEAD"))
 	if err != nil {
 		return "", err
 	}
-	head := strings.TrimSpace(string(content))
 	if head == "" {
 		return "", errors.New("empty HEAD")
 	}
@@ -251,13 +250,18 @@ func resolveHeadHashFromHead(layout gitLayout, head string) (string, error) {
 	}
 
 	refName := strings.TrimSpace(strings.TrimPrefix(head, "ref: "))
+	refPathSuffix := filepath.FromSlash(refName)
 	for _, baseDir := range []string{layout.gitDir, layout.commonDir} {
-		refPath := filepath.Join(baseDir, filepath.FromSlash(refName))
-		if refValue, err := os.ReadFile(refPath); err == nil {
-			hash := strings.TrimSpace(string(refValue))
+		refPath := filepath.Join(baseDir, refPathSuffix)
+		hash, err := readTrimmedSmallFile(refPath)
+		if err == nil {
 			if hash != "" {
 				return hash, nil
 			}
+			continue
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
 		}
 	}
 
@@ -386,11 +390,11 @@ func readCommitEpochFromObjects(objectDir, hash string) (int64, error) {
 			return 0, err
 		}
 		if strings.HasPrefix(line, "committer ") {
-			fields := strings.Fields(strings.TrimSpace(line))
-			if len(fields) < 3 {
-				break
+			epochText, parseErr := parseCommitterEpoch(line)
+			if parseErr != nil {
+				return 0, parseErr
 			}
-			epoch, parseErr := strconv.ParseInt(fields[len(fields)-2], 10, 64)
+			epoch, parseErr := strconv.ParseInt(epochText, 10, 64)
 			if parseErr != nil {
 				return 0, parseErr
 			}
@@ -440,6 +444,43 @@ func acquireCommitObjectReader(r io.Reader) *bufio.Reader {
 func releaseCommitObjectReader(reader *bufio.Reader) {
 	reader.Reset(strings.NewReader(""))
 	commitObjectReaderPool.Put(reader)
+}
+
+func readTrimmedSmallFile(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	var buf [512]byte
+	n, err := file.Read(buf[:])
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	if n == 0 {
+		return "", nil
+	}
+	if n == len(buf) {
+		var extra [1]byte
+		if extraN, extraErr := file.Read(extra[:]); extraErr == nil || (extraErr == io.EOF && extraN > 0) {
+			return "", errors.New("git metadata file too large")
+		}
+	}
+	return strings.TrimSpace(string(buf[:n])), nil
+}
+
+func parseCommitterEpoch(line string) (string, error) {
+	line = strings.TrimSpace(line)
+	lastSpace := strings.LastIndexByte(line, ' ')
+	if lastSpace < 0 {
+		return "", errors.New("invalid committer line")
+	}
+	prevSpace := strings.LastIndexByte(line[:lastSpace], ' ')
+	if prevSpace < 0 || prevSpace+1 >= lastSpace {
+		return "", errors.New("invalid committer line")
+	}
+	return line[prevSpace+1 : lastSpace], nil
 }
 
 func gitIsDirty(dir string) (bool, error) {

--- a/cmd/workspace-launcher/git.go
+++ b/cmd/workspace-launcher/git.go
@@ -12,6 +12,21 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
+)
+
+type resettableZlibReader interface {
+	io.ReadCloser
+	Reset(io.Reader, []byte) error
+}
+
+var (
+	commitObjectReaderPool = sync.Pool{
+		New: func() any {
+			return bufio.NewReaderSize(strings.NewReader(""), 1024)
+		},
+	}
+	zlibReaderPool sync.Pool
 )
 
 func inspectGitMeta(dir string, gitIsDir, wantBranch, wantEpoch, wantDirty bool) gitMeta {
@@ -66,7 +81,11 @@ func inspectGitMeta(dir string, gitIsDir, wantBranch, wantEpoch, wantDirty bool)
 		meta.isWorktree = false
 	}
 	if wantEpoch {
-		layout, layoutErr := finalizeGitLayout(gitDir)
+		layout := gitLayout{gitDir: gitDir, commonDir: gitDir}
+		var layoutErr error
+		if isWorktree {
+			layout, layoutErr = finalizeGitLayout(gitDir)
+		}
 		if layoutErr == nil {
 			head, headErr := readHeadFile(layout.gitDir)
 			if headErr == nil {
@@ -349,13 +368,14 @@ func readCommitEpochFromObjects(objectDir, hash string) (int64, error) {
 	}
 	defer file.Close()
 
-	reader, err := zlib.NewReader(file)
+	reader, err := acquireZlibReader(file)
 	if err != nil {
 		return 0, err
 	}
-	defer reader.Close()
+	defer releaseZlibReader(reader)
 
-	buf := bufio.NewReaderSize(reader, 1024)
+	buf := acquireCommitObjectReader(reader)
+	defer releaseCommitObjectReader(buf)
 	if _, err := buf.ReadBytes(0); err != nil {
 		return 0, errors.New("invalid object header")
 	}
@@ -382,6 +402,44 @@ func readCommitEpochFromObjects(objectDir, hash string) (int64, error) {
 	}
 
 	return 0, errors.New("committer line not found")
+}
+
+func acquireZlibReader(r io.Reader) (resettableZlibReader, error) {
+	if pooled := zlibReaderPool.Get(); pooled != nil {
+		reader := pooled.(resettableZlibReader)
+		if err := reader.Reset(r, nil); err == nil {
+			return reader, nil
+		}
+		_ = reader.Close()
+	}
+
+	reader, err := zlib.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	resettable, ok := reader.(resettableZlibReader)
+	if !ok {
+		_ = reader.Close()
+		return nil, errors.New("zlib reader does not support reset")
+	}
+	return resettable, nil
+}
+
+func releaseZlibReader(reader resettableZlibReader) {
+	_ = reader.Close()
+	zlibReaderPool.Put(reader)
+}
+
+func acquireCommitObjectReader(r io.Reader) *bufio.Reader {
+	reader := commitObjectReaderPool.Get().(*bufio.Reader)
+	reader.Reset(r)
+	return reader
+}
+
+func releaseCommitObjectReader(reader *bufio.Reader) {
+	reader.Reset(strings.NewReader(""))
+	commitObjectReaderPool.Put(reader)
 }
 
 func gitIsDirty(dir string) (bool, error) {

--- a/cmd/workspace-launcher/main_bench_test.go
+++ b/cmd/workspace-launcher/main_bench_test.go
@@ -156,6 +156,7 @@ func BenchmarkPickRepoHeadless_QueryMatchEarly(b *testing.B) {
 			cands := makeBenchCandidates(candCount)
 			cands[0].matchText = "needle-early"
 			cands[0].display = "needle-early"
+			cands[0].searchText = buildCandidateSearchText(cands[0].matchText, cands[0].branchText)
 			cfg := config{
 				headlessBench: true,
 				initialQuery:  "needle-early",
@@ -190,6 +191,7 @@ func BenchmarkPickRepoHeadless_QueryMatchLate(b *testing.B) {
 			cands := makeBenchCandidates(candCount)
 			last := len(cands) - 1
 			cands[last].branchText = "feature/needle-late"
+			cands[last].searchText = buildCandidateSearchText(cands[last].matchText, cands[last].branchText)
 			cfg := config{
 				headlessBench: true,
 				initialQuery:  "needle-late",
@@ -290,11 +292,13 @@ func makeBenchCandidates(count int) []candidate {
 	cands := make([]candidate, count)
 	for i := range count {
 		name := fmt.Sprintf("repo-%04d", i)
+		branch := fmt.Sprintf("feature/%s", name)
 		cands[i] = candidate{
 			path:       filepath.Join("/tmp/workspaces", name),
 			display:    name,
 			matchText:  name,
-			branchText: fmt.Sprintf("feature/%s", name),
+			branchText: branch,
+			searchText: buildCandidateSearchText(name, branch),
 		}
 	}
 	return cands

--- a/cmd/workspace-launcher/main_bench_test.go
+++ b/cmd/workspace-launcher/main_bench_test.go
@@ -1,0 +1,301 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+var (
+	benchCandidatesSink []candidate
+	benchGitMetaSink    gitMeta
+	benchPickerSink     pickerResult
+)
+
+func BenchmarkBuildCandidates_Mtime(b *testing.B) {
+	for _, repoCount := range []int{100, 1000} {
+		repoCount := repoCount
+		b.Run(fmt.Sprintf("repos_%d", repoCount), func(b *testing.B) {
+			root := b.TempDir()
+			createBenchWorkspaceRoot(b, root, repoCount, false)
+			for _, jobs := range benchmarkJobCounts() {
+				jobs := jobs
+				b.Run(fmt.Sprintf("jobs_%d", jobs), func(b *testing.B) {
+					cfg := benchmarkConfig(root, jobs, recencyMtime)
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						cands, err := buildCandidates(cfg)
+						if err != nil {
+							b.Fatalf("buildCandidates returned error: %v", err)
+						}
+						benchCandidatesSink = cands
+					}
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkBuildCandidates_GitRecency(b *testing.B) {
+	for _, repoCount := range []int{100, 1000} {
+		repoCount := repoCount
+		b.Run(fmt.Sprintf("repos_%d", repoCount), func(b *testing.B) {
+			root := b.TempDir()
+			createBenchWorkspaceRoot(b, root, repoCount, true)
+			for _, jobs := range benchmarkJobCounts() {
+				jobs := jobs
+				b.Run(fmt.Sprintf("jobs_%d", jobs), func(b *testing.B) {
+					cfg := benchmarkConfig(root, jobs, recencyGit)
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						cands, err := buildCandidates(cfg)
+						if err != nil {
+							b.Fatalf("buildCandidates returned error: %v", err)
+						}
+						benchCandidatesSink = cands
+					}
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkInspectGitMeta_RegularRepo(b *testing.B) {
+	repo := initTestRepo(b)
+	commitAt(b, repo, "1700000000", "regular")
+
+	meta := inspectGitMeta(repo, true, true, true, false)
+	if !meta.present || meta.epoch == 0 {
+		b.Fatalf("unexpected git metadata: %+v", meta)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchGitMetaSink = inspectGitMeta(repo, true, true, true, false)
+	}
+}
+
+func BenchmarkInspectGitMeta_PackedRefs(b *testing.B) {
+	repo := initTestRepo(b)
+	commitAt(b, repo, "1700000100", "packed")
+	runGit(b, repo, "pack-refs", "--all")
+
+	refPath := filepath.Join(repo, ".git", "refs", "heads", currentBranchName(b, repo))
+	if err := os.Remove(refPath); err != nil && !os.IsNotExist(err) {
+		b.Fatalf("remove loose ref: %v", err)
+	}
+
+	meta := inspectGitMeta(repo, true, true, true, false)
+	if !meta.present || meta.epoch == 0 {
+		b.Fatalf("unexpected git metadata: %+v", meta)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchGitMetaSink = inspectGitMeta(repo, true, true, true, false)
+	}
+}
+
+func BenchmarkInspectGitMeta_Worktree(b *testing.B) {
+	repo := initTestRepo(b)
+	commitAt(b, repo, "1700000200", "worktree")
+
+	worktree := filepath.Join(b.TempDir(), "wt")
+	runGit(b, repo, "worktree", "add", worktree)
+
+	meta := inspectGitMeta(worktree, false, true, true, false)
+	if !meta.present || !meta.isWorktree || meta.epoch == 0 {
+		b.Fatalf("unexpected git metadata: %+v", meta)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchGitMetaSink = inspectGitMeta(worktree, false, true, true, false)
+	}
+}
+
+func BenchmarkPickRepoHeadless_EmptyQuery(b *testing.B) {
+	for _, candCount := range []int{100, 1000} {
+		candCount := candCount
+		b.Run(fmt.Sprintf("cands_%d", candCount), func(b *testing.B) {
+			cfg := config{headlessBench: true, roots: []string{"/tmp/workspaces"}}
+			cands := makeBenchCandidates(candCount)
+
+			got, err := pickRepoHeadless(cfg, cands)
+			if err != nil {
+				b.Fatalf("pickRepoHeadless returned error: %v", err)
+			}
+			if got.selection == "" {
+				b.Fatal("expected a selection")
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result, err := pickRepoHeadless(cfg, cands)
+				if err != nil {
+					b.Fatalf("pickRepoHeadless returned error: %v", err)
+				}
+				benchPickerSink = result
+			}
+		})
+	}
+}
+
+func BenchmarkPickRepoHeadless_QueryMatchEarly(b *testing.B) {
+	for _, candCount := range []int{100, 1000} {
+		candCount := candCount
+		b.Run(fmt.Sprintf("cands_%d", candCount), func(b *testing.B) {
+			cands := makeBenchCandidates(candCount)
+			cands[0].matchText = "needle-early"
+			cands[0].display = "needle-early"
+			cfg := config{
+				headlessBench: true,
+				initialQuery:  "needle-early",
+				roots:         []string{"/tmp/workspaces"},
+			}
+
+			got, err := pickRepoHeadless(cfg, cands)
+			if err != nil {
+				b.Fatalf("pickRepoHeadless returned error: %v", err)
+			}
+			if got.selection == "" {
+				b.Fatal("expected a selection")
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result, err := pickRepoHeadless(cfg, cands)
+				if err != nil {
+					b.Fatalf("pickRepoHeadless returned error: %v", err)
+				}
+				benchPickerSink = result
+			}
+		})
+	}
+}
+
+func BenchmarkPickRepoHeadless_QueryMatchLate(b *testing.B) {
+	for _, candCount := range []int{100, 1000} {
+		candCount := candCount
+		b.Run(fmt.Sprintf("cands_%d", candCount), func(b *testing.B) {
+			cands := makeBenchCandidates(candCount)
+			last := len(cands) - 1
+			cands[last].branchText = "feature/needle-late"
+			cfg := config{
+				headlessBench: true,
+				initialQuery:  "needle-late",
+				roots:         []string{"/tmp/workspaces"},
+			}
+
+			got, err := pickRepoHeadless(cfg, cands)
+			if err != nil {
+				b.Fatalf("pickRepoHeadless returned error: %v", err)
+			}
+			if got.selection == "" {
+				b.Fatal("expected a selection")
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result, err := pickRepoHeadless(cfg, cands)
+				if err != nil {
+					b.Fatalf("pickRepoHeadless returned error: %v", err)
+				}
+				benchPickerSink = result
+			}
+		})
+	}
+}
+
+func benchmarkJobCounts() []int {
+	maxJobs := runtime.NumCPU()
+	if maxJobs < 1 {
+		maxJobs = 1
+	}
+	if maxJobs == 1 {
+		return []int{1}
+	}
+	return []int{1, maxJobs}
+}
+
+func benchmarkConfig(root string, jobs int, recency string) config {
+	return config{
+		mode:         modePath,
+		fzfStyle:     fzfStylePlain,
+		roots:        []string{root},
+		jobs:         jobs,
+		recency:      recency,
+		showLanguage: true,
+		showGit:      true,
+		now:          1700005000,
+		cols:         120,
+		nameWidth:    32,
+	}
+}
+
+func createBenchWorkspaceRoot(b testing.TB, root string, repoCount int, withGit bool) {
+	b.Helper()
+	for i := 0; i < repoCount; i++ {
+		dir := filepath.Join(root, fmt.Sprintf("repo-%04d", i))
+		epoch := int64(1700000000 + i)
+		if withGit {
+			makeBenchGitRepo(b, dir, epoch, benchmarkMarkerFile(i))
+			continue
+		}
+		makeDir(b, dir, epoch, benchmarkMarkerFile(i))
+	}
+}
+
+func makeBenchGitRepo(b testing.TB, dir string, epoch int64, marker string) {
+	b.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		b.Fatalf("mkdir %s: %v", dir, err)
+	}
+	runGit(b, dir, "init")
+	runGit(b, dir, "config", "user.name", "test")
+	runGit(b, dir, "config", "user.email", "test@example.com")
+	if marker != "" {
+		if err := os.WriteFile(filepath.Join(dir, marker), []byte("x"), 0o644); err != nil {
+			b.Fatalf("write marker %s: %v", marker, err)
+		}
+	}
+	commitAt(b, dir, fmt.Sprintf("%d", epoch), fmt.Sprintf("commit-%d", epoch))
+	setDirTime(b, dir, epoch-100)
+}
+
+func benchmarkMarkerFile(index int) string {
+	markers := []string{
+		"go.mod",
+		"Cargo.toml",
+		"package.json",
+		"pyproject.toml",
+		"init.lua",
+		"Gemfile",
+		"flake.nix",
+	}
+	return markers[index%len(markers)]
+}
+
+func makeBenchCandidates(count int) []candidate {
+	cands := make([]candidate, count)
+	for i := range count {
+		name := fmt.Sprintf("repo-%04d", i)
+		cands[i] = candidate{
+			path:       filepath.Join("/tmp/workspaces", name),
+			display:    name,
+			matchText:  name,
+			branchText: fmt.Sprintf("feature/%s", name),
+		}
+	}
+	return cands
+}

--- a/cmd/workspace-launcher/main_test.go
+++ b/cmd/workspace-launcher/main_test.go
@@ -1398,7 +1398,7 @@ func TestResolveSelectionUsesFirstRootWhenActiveRootIsAll(t *testing.T) {
 	}
 }
 
-func makeDir(t *testing.T, dir string, epoch int64, marker string) {
+func makeDir(t testing.TB, dir string, epoch int64, marker string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir %s: %v", dir, err)
@@ -1411,7 +1411,7 @@ func makeDir(t *testing.T, dir string, epoch int64, marker string) {
 	setDirTime(t, dir, epoch)
 }
 
-func makeGitRepo(t *testing.T, dir string, epoch int64) {
+func makeGitRepo(t testing.TB, dir string, epoch int64) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir %s: %v", dir, err)
@@ -1438,7 +1438,7 @@ func makeGitRepo(t *testing.T, dir string, epoch int64) {
 	setDirTime(t, dir, epoch-100)
 }
 
-func initTestRepo(t *testing.T) string {
+func initTestRepo(t testing.TB) string {
 	t.Helper()
 	repo := t.TempDir()
 	runGit(t, repo, "init")
@@ -1447,7 +1447,7 @@ func initTestRepo(t *testing.T) string {
 	return repo
 }
 
-func commitAt(t *testing.T, repo, epoch, contents string) {
+func commitAt(t testing.TB, repo, epoch, contents string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(repo, "f.txt"), []byte(contents), 0o644); err != nil {
 		t.Fatalf("write file: %v", err)
@@ -1467,7 +1467,7 @@ func commitAt(t *testing.T, repo, epoch, contents string) {
 	}
 }
 
-func currentBranchName(t *testing.T, repo string) string {
+func currentBranchName(t testing.TB, repo string) string {
 	t.Helper()
 	branch := strings.TrimSpace(runGit(t, repo, "rev-parse", "--abbrev-ref", "HEAD"))
 	if branch == "" || branch == "HEAD" {
@@ -1476,7 +1476,7 @@ func currentBranchName(t *testing.T, repo string) string {
 	return branch
 }
 
-func setDirTime(t *testing.T, dir string, epoch int64) {
+func setDirTime(t testing.TB, dir string, epoch int64) {
 	t.Helper()
 	ts := time.Unix(epoch, 0)
 	if err := os.Chtimes(dir, ts, ts); err != nil {
@@ -1484,7 +1484,7 @@ func setDirTime(t *testing.T, dir string, epoch int64) {
 	}
 }
 
-func runGit(t *testing.T, dir string, args ...string) string {
+func runGit(t testing.TB, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
 	cmd.Env = append(os.Environ(),
@@ -1499,7 +1499,7 @@ func runGit(t *testing.T, dir string, args ...string) string {
 	return string(output)
 }
 
-func writeTestScript(t *testing.T, content string) string {
+func writeTestScript(t testing.TB, content string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "test-script.sh")
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {

--- a/cmd/workspace-launcher/picker.go
+++ b/cmd/workspace-launcher/picker.go
@@ -220,9 +220,8 @@ func fzfSearchNth(cfg config) string {
 func pickRepoHeadless(cfg config, candidates []candidate) (pickerResult, error) {
 	query := strings.ToLower(cfg.initialQuery)
 	for _, cand := range candidates {
-		line := serializeCandidate(cand)
-		if query == "" || strings.Contains(strings.ToLower(candidateSearchText(cand)), query) {
-			return pickerResult{selection: line, createRoot: defaultCreateRoot(cfg)}, nil
+		if query == "" || strings.Contains(candidateSearchText(cand), query) {
+			return pickerResult{selection: serializeCandidate(cand), createRoot: defaultCreateRoot(cfg)}, nil
 		}
 	}
 	return pickerResult{}, exitCodeError{code: 1}
@@ -275,10 +274,17 @@ func serializeCandidate(cand candidate) string {
 }
 
 func candidateSearchText(cand candidate) string {
-	if cand.branchText == "" {
-		return cand.matchText
+	if cand.searchText != "" {
+		return cand.searchText
 	}
-	return cand.matchText + " " + cand.branchText
+	return buildCandidateSearchText(cand.matchText, cand.branchText)
+}
+
+func buildCandidateSearchText(matchText, branchText string) string {
+	if branchText == "" {
+		return strings.ToLower(matchText)
+	}
+	return strings.ToLower(matchText + " " + branchText)
 }
 
 func branchSearchText(branch string) string {

--- a/cmd/workspace-launcher/scan.go
+++ b/cmd/workspace-launcher/scan.go
@@ -150,6 +150,7 @@ func renderCandidates(cfg config, details []repoDetails) []candidate {
 		if branch == "" {
 			branch = "-"
 		}
+		branchText := branchSearchText(detail.git.branchLabel)
 
 		markerField := paintFieldStyled(styled, cDim, " ")
 		if isCurrentRepo(cfg.cwd, detail.child.path) {
@@ -175,7 +176,8 @@ func renderCandidates(cfg config, details []repoDetails) []candidate {
 			path:       detail.child.path,
 			display:    joinDisplayFields(fields),
 			matchText:  detail.matchText,
-			branchText: branchSearchText(detail.git.branchLabel),
+			branchText: branchText,
+			searchText: buildCandidateSearchText(detail.matchText, branchText),
 			epoch:      detail.epoch,
 		}
 	}

--- a/cmd/workspace-launcher/scan.go
+++ b/cmd/workspace-launcher/scan.go
@@ -124,6 +124,7 @@ func inspectRepo(cfg config, child childDir, inspect bool) (repoDetails, error) 
 		lang:      lang,
 		git:       git,
 		matchText: child.name,
+		ageText:   formatAge(cfg.now, epoch),
 		epoch:     epoch,
 	}, nil
 }
@@ -157,7 +158,7 @@ func renderCandidates(cfg config, details []repoDetails) []candidate {
 			markerField = paintFieldStyled(styled, cCurrent, "*")
 		}
 		nameField := markerField + " " + paintFieldStyled(styled, cName, fitField(detail.child.name, cfg.nameWidth))
-		ageField := renderAgeFieldStyled(formatAge(cfg.now, detail.epoch), cfg.ageColumnWidth, styled)
+		ageField := renderAgeFieldStyled(detail.ageText, cfg.ageColumnWidth, styled)
 
 		fields := make([]string, 0, 4)
 		if cfg.showRoot {

--- a/cmd/workspace-launcher/types.go
+++ b/cmd/workspace-launcher/types.go
@@ -114,6 +114,7 @@ type repoDetails struct {
 	lang      string
 	git       gitMeta
 	matchText string
+	ageText   string
 	epoch     int64
 }
 

--- a/cmd/workspace-launcher/types.go
+++ b/cmd/workspace-launcher/types.go
@@ -98,6 +98,7 @@ type candidate struct {
 	display    string
 	matchText  string
 	branchText string
+	searchText string
 	epoch      int64
 }
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,6 +1,37 @@
 # Benchmarking
 
-Run the default benchmark flow end-to-end:
+## Native Go Benchmarks
+
+Use Go's native benchmark runner for targeted hot paths:
+
+```sh
+just bench-go
+```
+
+That runs:
+
+```sh
+go test ./cmd/workspace-launcher -run '^$' -bench . -benchmem
+```
+
+The native suite currently covers these core paths in `cmd/workspace-launcher`:
+
+- `buildCandidates` with `mtime` and `git` recency
+- `inspectGitMeta` for regular repos, packed refs, and linked worktrees
+- `pickRepoHeadless` for empty-query, early-match, and late-match scans
+
+Run a subset directly:
+
+```sh
+go test ./cmd/workspace-launcher -run '^$' -bench 'BuildCandidates|InspectGitMeta' -benchmem
+```
+
+Use the native suite when you want per-function allocation data and tighter feedback
+while working on a specific hot path.
+
+## End-to-End Headless Benchmarks
+
+Run the full app-level benchmark flow:
 
 ```sh
 just bench
@@ -10,7 +41,7 @@ That builds the binaries, prepares the synthetic fixture under
 `/tmp/workspace-launcher-bench`, and runs the `mtime` and `git` recency
 benchmarks with `hyperfine`.
 
-Create the synthetic fixture tree:
+Create the synthetic fixture tree manually:
 
 ```sh
 just build
@@ -37,12 +68,12 @@ Override the size or location:
 just bench /tmp/wl-bench 2500
 ```
 
-Run the launcher in built-in headless benchmark mode:
+Run the launcher in built-in headless benchmark mode directly:
 
 ```sh
 hyperfine --warmup 3 'WORKSPACE_LAUNCHER_BENCH_MODE=headless ./.build/workspace-launcher /tmp/workspace-launcher-bench >/dev/null'
 hyperfine --warmup 3 'WORKSPACE_LAUNCHER_BENCH_MODE=headless WORKSPACE_LAUNCHER_RECENCY=git ./.build/workspace-launcher /tmp/workspace-launcher-bench >/dev/null'
 ```
 
-The stored pre-optimization reference for March 7, 2026 lives in
-[`docs/performance-baseline.md`](performance-baseline.md).
+Use the headless flow when you want end-to-end timings for the actual binary across a
+large synthetic workspace tree.

--- a/justfile
+++ b/justfile
@@ -43,6 +43,9 @@ bench root="/tmp/workspace-launcher-bench" count="1500" warmup="3":
       "WORKSPACE_LAUNCHER_BENCH_MODE=headless ./.build/workspace-launcher {{root}} >/dev/null" \
       "WORKSPACE_LAUNCHER_BENCH_MODE=headless WORKSPACE_LAUNCHER_RECENCY=git ./.build/workspace-launcher {{root}} >/dev/null"
 
+bench-go filter=".":
+    go test ./cmd/workspace-launcher -run '^$' -bench "{{filter}}" -benchmem
+
 run *args:
     just build
     ./.build/workspace-launcher {{args}}


### PR DESCRIPTION
## Summary
- Add a native Go benchmark suite in `cmd/workspace-launcher/main_bench_test.go` covering `buildCandidates`, `inspectGitMeta`, and `pickRepoHeadless` scenarios.
- Add `just bench-go` and document two benchmark workflows: native `go test -bench` and end-to-end `hyperfine` headless runs.
- Improve display/render performance by reusing precomputed age text and reducing string allocations in field joining and age truncation logic.
- Speed up headless matching by precomputing lowercase candidate search text and reusing it during scans.
- Tighten git metadata parsing and object reads with small-file readers, committer epoch parsing improvements, and pooled zlib/buffered readers for commit object parsing.
- Broaden shared test helpers in `main_test.go` from `*testing.T` to `testing.TB` for reuse in benchmarks.

## Testing
- `go test ./cmd/workspace-launcher -run '^$' -bench . -benchmem` (native benchmark suite)
- `just bench-go` (task wiring and benchmark invocation)
- `just bench` (end-to-end headless benchmark flow with `hyperfine`)
- Not run: full unit/integration test suite outside benchmark targets